### PR TITLE
Testing AI code agents, Claude Code: add episode browsing

### DIFF
--- a/infrastructure/episode_index_lambda.py
+++ b/infrastructure/episode_index_lambda.py
@@ -1,0 +1,300 @@
+"""
+AWS Lambda function for generating ZorkGPT episode index.
+
+This function scans S3 snapshots to build an index of all available episodes,
+providing metadata like final score, turn count, duration, and status.
+"""
+
+import json
+import boto3
+import re
+from datetime import datetime
+from typing import Dict, List, Optional, Any
+import logging
+
+# Set up logging
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+# Initialize S3 client
+s3_client = boto3.client('s3')
+
+
+def lambda_handler(event, context):
+    """
+    Main Lambda handler for episode index generation.
+    
+    Returns:
+        dict: API Gateway response with episode index data
+    """
+    try:
+        # Get bucket name from environment or event
+        bucket_name = event.get('queryStringParameters', {}).get('bucket') if event.get('queryStringParameters') else None
+        if not bucket_name:
+            bucket_name = context.get('bucket_name') or 'zorkgpt-viewer-bucket'
+        
+        logger.info(f"Generating episode index for bucket: {bucket_name}")
+        
+        # Get episode list from S3
+        episodes = get_episode_list(bucket_name)
+        
+        # Build response
+        response_body = {
+            'episodes': episodes,
+            'total_count': len(episodes),
+            'generated_at': datetime.utcnow().isoformat() + 'Z'
+        }
+        
+        return {
+            'statusCode': 200,
+            'headers': {
+                'Content-Type': 'application/json',
+                'Access-Control-Allow-Origin': '*',
+                'Cache-Control': 'max-age=300'  # Cache for 5 minutes
+            },
+            'body': json.dumps(response_body)
+        }
+        
+    except Exception as e:
+        logger.error(f"Error generating episode index: {str(e)}")
+        return {
+            'statusCode': 500,
+            'headers': {
+                'Content-Type': 'application/json',
+                'Access-Control-Allow-Origin': '*'
+            },
+            'body': json.dumps({
+                'error': 'Internal server error',
+                'message': str(e)
+            })
+        }
+
+
+def get_episode_list(bucket_name: str) -> List[Dict[str, Any]]:
+    """
+    Scan S3 snapshots directory to build episode index.
+    
+    Args:
+        bucket_name: S3 bucket containing snapshots
+        
+    Returns:
+        List of episode metadata dictionaries
+    """
+    episodes = []
+    
+    try:
+        # List all episode directories in snapshots/
+        paginator = s3_client.get_paginator('list_objects_v2')
+        page_iterator = paginator.paginate(
+            Bucket=bucket_name,
+            Prefix='snapshots/',
+            Delimiter='/'
+        )
+        
+        episode_ids = set()
+        
+        # Extract episode IDs from S3 directory structure
+        for page in page_iterator:
+            for prefix_info in page.get('CommonPrefixes', []):
+                prefix = prefix_info['Prefix']
+                # Extract episode ID from path like 'snapshots/2025-06-03T13:01:40/'
+                episode_match = re.match(r'snapshots/([^/]+)/', prefix)
+                if episode_match:
+                    episode_ids.add(episode_match.group(1))
+        
+        logger.info(f"Found {len(episode_ids)} episodes")
+        
+        # Get metadata for each episode
+        for episode_id in sorted(episode_ids, reverse=True):  # Most recent first
+            try:
+                episode_data = get_episode_metadata(bucket_name, episode_id)
+                if episode_data:
+                    episodes.append(episode_data)
+            except Exception as e:
+                logger.warning(f"Failed to get metadata for episode {episode_id}: {str(e)}")
+                # Include episode even if we can't get full metadata
+                episodes.append({
+                    'episode_id': episode_id,
+                    'status': 'unknown',
+                    'error': str(e)
+                })
+        
+    except Exception as e:
+        logger.error(f"Error scanning S3 for episodes: {str(e)}")
+        raise
+    
+    return episodes
+
+
+def get_episode_metadata(bucket_name: str, episode_id: str) -> Optional[Dict[str, Any]]:
+    """
+    Extract metadata from the final snapshot of an episode.
+    
+    Args:
+        bucket_name: S3 bucket name
+        episode_id: Episode identifier
+        
+    Returns:
+        Episode metadata dictionary or None if not found
+    """
+    try:
+        # Find the highest turn number for this episode
+        response = s3_client.list_objects_v2(
+            Bucket=bucket_name,
+            Prefix=f'snapshots/{episode_id}/turn_',
+            MaxKeys=1000
+        )
+        
+        if 'Contents' not in response:
+            logger.warning(f"No snapshots found for episode {episode_id}")
+            return None
+        
+        # Extract turn numbers and find the highest
+        turn_files = []
+        for obj in response['Contents']:
+            key = obj['Key']
+            turn_match = re.search(r'turn_(\d+)\.json$', key)
+            if turn_match:
+                turn_number = int(turn_match.group(1))
+                turn_files.append((turn_number, key, obj['LastModified']))
+        
+        if not turn_files:
+            logger.warning(f"No valid turn files found for episode {episode_id}")
+            return None
+        
+        # Get the final turn snapshot
+        final_turn, final_key, last_modified = max(turn_files, key=lambda x: x[0])
+        
+        # Download and parse the final snapshot
+        obj_response = s3_client.get_object(Bucket=bucket_name, Key=final_key)
+        snapshot_data = json.loads(obj_response['Body'].read().decode('utf-8'))
+        
+        # Extract metadata
+        metadata = snapshot_data.get('metadata', {})
+        current_state = snapshot_data.get('current_state', {})
+        
+        # Calculate episode duration
+        start_time = parse_episode_start_time(episode_id)
+        duration_minutes = None
+        if start_time and last_modified:
+            # Convert last_modified to naive datetime for comparison
+            end_time = last_modified.replace(tzinfo=None)
+            duration = end_time - start_time
+            duration_minutes = round(duration.total_seconds() / 60, 1)
+        
+        # Determine episode status
+        status = determine_episode_status(snapshot_data, final_turn)
+        
+        return {
+            'episode_id': episode_id,
+            'start_time': episode_id,  # Episode ID is the start timestamp
+            'final_turn': final_turn,
+            'score': metadata.get('score', 0),
+            'max_turns': metadata.get('max_turns', 0),
+            'location': current_state.get('location', 'Unknown'),
+            'death_count': current_state.get('death_count', 0),
+            'status': status,
+            'duration_minutes': duration_minutes,
+            'last_modified': last_modified.isoformat(),
+            'models': metadata.get('models', {}),
+            'completion_percent': round((final_turn / metadata.get('max_turns', 1)) * 100, 1) if metadata.get('max_turns') else 0
+        }
+        
+    except Exception as e:
+        logger.error(f"Error getting metadata for episode {episode_id}: {str(e)}")
+        return None
+
+
+def parse_episode_start_time(episode_id: str) -> Optional[datetime]:
+    """
+    Parse episode start time from episode ID.
+    
+    Args:
+        episode_id: Episode ID in format YYYY-MM-DDTHH:MM:SS
+        
+    Returns:
+        datetime object or None if parsing fails
+    """
+    try:
+        return datetime.strptime(episode_id, "%Y-%m-%dT%H:%M:%S")
+    except ValueError:
+        logger.warning(f"Could not parse episode start time from ID: {episode_id}")
+        return None
+
+
+def determine_episode_status(snapshot_data: Dict, final_turn: int) -> str:
+    """
+    Determine episode status based on final snapshot data.
+    
+    Args:
+        snapshot_data: Final snapshot data
+        final_turn: Final turn number
+        
+    Returns:
+        Status string ('completed', 'in_progress', 'died', 'abandoned')
+    """
+    metadata = snapshot_data.get('metadata', {})
+    current_state = snapshot_data.get('current_state', {})
+    
+    max_turns = metadata.get('max_turns', 0)
+    death_count = current_state.get('death_count', 0)
+    score = metadata.get('score', 0)
+    
+    # Check if episode reached max turns
+    if max_turns > 0 and final_turn >= max_turns:
+        if score > 300:  # High score indicates good completion
+            return 'completed'
+        else:
+            return 'max_turns_reached'
+    
+    # Check if player died multiple times (likely abandoned)
+    if death_count >= 3:
+        return 'died'
+    
+    # Check if it's a very short episode (likely abandoned)
+    if final_turn < 10:
+        return 'abandoned'
+    
+    # Check score-based completion (Zork typically ends around 350 points)
+    if score >= 350:
+        return 'completed'
+    
+    # If recent activity, consider in progress
+    # (This would need timestamp checking in a real implementation)
+    return 'in_progress'
+
+
+def get_episode_summary_stats(episodes: List[Dict]) -> Dict[str, Any]:
+    """
+    Generate summary statistics for episode list.
+    
+    Args:
+        episodes: List of episode metadata
+        
+    Returns:
+        Summary statistics dictionary
+    """
+    if not episodes:
+        return {}
+    
+    total_episodes = len(episodes)
+    total_turns = sum(ep.get('final_turn', 0) for ep in episodes)
+    avg_turns = round(total_turns / total_episodes, 1) if total_episodes > 0 else 0
+    
+    scores = [ep.get('score', 0) for ep in episodes if ep.get('score', 0) > 0]
+    avg_score = round(sum(scores) / len(scores), 1) if scores else 0
+    max_score = max(scores) if scores else 0
+    
+    status_counts = {}
+    for episode in episodes:
+        status = episode.get('status', 'unknown')
+        status_counts[status] = status_counts.get(status, 0) + 1
+    
+    return {
+        'total_episodes': total_episodes,
+        'total_turns': total_turns,
+        'average_turns': avg_turns,
+        'average_score': avg_score,
+        'max_score': max_score,
+        'status_distribution': status_counts
+    }

--- a/infrastructure/zorkgpt_viewer_stack.py
+++ b/infrastructure/zorkgpt_viewer_stack.py
@@ -191,7 +191,8 @@ class ZorkGPTViewerStack(Stack):
             timeout=Duration.seconds(30),
             memory_size=256,
             environment={
-                "BUCKET_NAME": self.bucket.bucket_name
+                "BUCKET_NAME": self.bucket.bucket_name,
+                "CLOUDFRONT_DOMAIN": self.distribution.distribution_domain_name
             }
         )
 
@@ -205,9 +206,13 @@ class ZorkGPTViewerStack(Stack):
             rest_api_name="ZorkGPT Episode Index API",
             description="API for retrieving ZorkGPT episode history",
             default_cors_preflight_options=apigateway.CorsOptions(
-                allow_origins=apigateway.Cors.ALL_ORIGINS,
-                allow_methods=apigateway.Cors.ALL_METHODS,
-                allow_headers=["Content-Type", "Authorization"]
+                allow_origins=[
+                    f"https://{domain_name}",
+                    f"https://www.{domain_name}",
+                    f"https://{self.distribution.distribution_domain_name}"
+                ],
+                allow_methods=["GET", "OPTIONS"],
+                allow_headers=["Content-Type", "Authorization", "Cache-Control"]
             )
         )
 

--- a/zork_viewer.html
+++ b/zork_viewer.html
@@ -684,6 +684,179 @@
             text-align: center;
             margin: 5px 0;
         }
+
+        /* Episode Selection Styles */
+        .episode-clickable {
+            cursor: pointer;
+            color: #007bff;
+            text-decoration: underline;
+            transition: color 0.2s;
+        }
+
+        .episode-clickable:hover {
+            color: #0056b3;
+        }
+
+        .episode-modal-content {
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            background: white;
+            padding: 30px;
+            border-radius: 12px;
+            max-width: 800px;
+            max-height: 80vh;
+            overflow-y: auto;
+            box-shadow: 0 4px 20px rgba(0,0,0,0.3);
+        }
+
+        .episode-modal-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 20px;
+        }
+
+        .episode-list {
+            max-height: 400px;
+            overflow-y: auto;
+            border: 1px solid #ddd;
+            border-radius: 6px;
+        }
+
+        .episode-item {
+            padding: 12px 16px;
+            border-bottom: 1px solid #eee;
+            cursor: pointer;
+            transition: background-color 0.2s;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        .episode-item:hover {
+            background-color: #f8f9fa;
+        }
+
+        .episode-item:last-child {
+            border-bottom: none;
+        }
+
+        .episode-item.current-episode {
+            background-color: #e3f2fd;
+            font-weight: bold;
+        }
+
+        .episode-main-info {
+            flex: 1;
+        }
+
+        .episode-title {
+            font-weight: bold;
+            color: #333;
+            margin-bottom: 4px;
+        }
+
+        .episode-details {
+            font-size: 0.9em;
+            color: #666;
+        }
+
+        .episode-stats {
+            text-align: right;
+            font-size: 0.9em;
+        }
+
+        .episode-score {
+            font-weight: bold;
+            color: #28a745;
+        }
+
+        .episode-status {
+            padding: 2px 6px;
+            border-radius: 3px;
+            font-size: 0.8em;
+            font-weight: bold;
+            text-transform: uppercase;
+        }
+
+        .status-completed {
+            background-color: #d4edda;
+            color: #155724;
+        }
+
+        .status-in_progress {
+            background-color: #d1ecf1;
+            color: #0c5460;
+        }
+
+        .status-died {
+            background-color: #f8d7da;
+            color: #721c24;
+        }
+
+        .status-abandoned {
+            background-color: #e2e3e5;
+            color: #383d41;
+        }
+
+        .episode-loading {
+            text-align: center;
+            padding: 20px;
+            color: #666;
+            font-style: italic;
+        }
+
+        .episode-error {
+            text-align: center;
+            padding: 20px;
+            color: #dc3545;
+            background-color: #f8d7da;
+            border-radius: 6px;
+            margin: 10px 0;
+        }
+
+        /* Mobile responsive episode modal */
+        @media (max-width: 768px) {
+            .episode-modal-content {
+                position: fixed;
+                top: 0;
+                left: 0;
+                right: 0;
+                bottom: 0;
+                transform: none;
+                max-width: none;
+                max-height: none;
+                border-radius: 0;
+                padding: 20px;
+                margin: 0;
+            }
+            
+            .episode-modal-header {
+                flex-direction: column;
+                align-items: flex-start;
+                gap: 10px;
+                margin-bottom: 15px;
+            }
+            
+            .episode-modal-header button {
+                position: absolute !important;
+                top: 15px !important;
+                right: 15px !important;
+            }
+
+            .episode-item {
+                flex-direction: column;
+                align-items: flex-start;
+                gap: 8px;
+            }
+
+            .episode-stats {
+                text-align: left;
+                width: 100%;
+            }
+        }
     </style>
 </head>
 <body>
@@ -705,7 +878,8 @@
             </div>
             <div class="info-grid">
                 <div class="info-item">
-                    <strong>Episode:</strong> <span id="episode-id">Loading...</span>
+                    <strong>Episode:</strong> 
+                    <span id="episode-id" class="episode-clickable" title="Click to view episode history">Loading...</span>
                 </div>
                 <div class="info-item">
                     <strong>Turn:</strong> <span id="turn-count">-</span> / <span id="max-turns">-</span>
@@ -844,6 +1018,19 @@
             <div class="map-modal-body">
                 <div id="map-diagram-expanded" class="loading">Loading map...</div>
                 <div id="map-stats-expanded" class="map-stats"></div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Episode History Modal -->
+    <div id="episode-modal" style="display: none; position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.5); z-index: 2000;">
+        <div class="episode-modal-content">
+            <div class="episode-modal-header">
+                <h2 style="margin: 0; color: #333;">Episode History</h2>
+                <button onclick="hideEpisodeModal()" style="background: none; border: none; font-size: 24px; cursor: pointer; color: #666;">&times;</button>
+            </div>
+            <div id="episode-list-container">
+                <div class="episode-loading">Loading episodes...</div>
             </div>
         </div>
     </div>
@@ -1084,6 +1271,63 @@
             }
         }
 
+        // Episode Manager for handling episode selection and loading
+        class EpisodeManager {
+            constructor(baseUrl) {
+                this.baseUrl = baseUrl;
+                this.episodeCache = null;
+                this.selectedEpisodeId = null;
+            }
+
+            async fetchEpisodeList() {
+                try {
+                    const response = await fetch(`${this.baseUrl}/api/episodes`);
+                    if (!response.ok) {
+                        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+                    }
+                    const data = await response.json();
+                    this.episodeCache = data;
+                    return data;
+                } catch (error) {
+                    console.error('Failed to fetch episode list:', error);
+                    throw error;
+                }
+            }
+
+            async loadEpisodeData(episodeId) {
+                try {
+                    // Load the episode's final state
+                    const response = await fetch(`${this.baseUrl}/snapshots/${episodeId}/current_state.json`);
+                    if (!response.ok) {
+                        throw new Error(`HTTP ${response.status}: Episode data not found`);
+                    }
+                    const episodeData = await response.json();
+                    this.selectedEpisodeId = episodeId;
+                    return episodeData;
+                } catch (error) {
+                    console.error(`Failed to load episode ${episodeId}:`, error);
+                    throw error;
+                }
+            }
+
+            formatEpisodeTitle(episode) {
+                const date = new Date(episode.start_time);
+                return `${date.toLocaleDateString()} ${date.toLocaleTimeString()}`;
+            }
+
+            formatDuration(minutes) {
+                if (!minutes) return 'Unknown';
+                if (minutes < 60) return `${minutes}m`;
+                const hours = Math.floor(minutes / 60);
+                const mins = minutes % 60;
+                return `${hours}h ${mins}m`;
+            }
+
+            getStatusClass(status) {
+                return `status-${status.replace('_', '')}`;
+            }
+        }
+
         class ZorkGameViewer {
             constructor(stateUrl) {
                 this.stateUrl = stateUrl;
@@ -1103,7 +1347,13 @@
                 this.isLoadingHistorical = false;
                 this.earliestLoadedTurn = null;
                 
+                // Episode management
+                this.episodeManager = new EpisodeManager('.');
+                this.isHistoricalView = false;
+                this.currentEpisodeId = null;
+                
                 this.startPolling();
+                this.setupEpisodeClickHandler();
             }
             
             async fetchCurrentState() {
@@ -1179,7 +1429,12 @@
             
             startPolling() {
                 this.fetchCurrentState();
-                setInterval(() => this.fetchCurrentState(), this.pollInterval);
+                setInterval(() => {
+                    // Only poll for current state if not in historical view
+                    if (!this.isHistoricalView) {
+                        this.fetchCurrentState();
+                    }
+                }, this.pollInterval);
                 
                 // Add scroll event listener to detect manual scrolling
                 const logContainer = document.getElementById('recent-log');
@@ -1230,11 +1485,166 @@
                 this.updateKnowledgeBase();
             }
             
+            setupEpisodeClickHandler() {
+                // Add click handler to episode ID
+                const episodeElement = document.getElementById('episode-id');
+                if (episodeElement) {
+                    episodeElement.addEventListener('click', () => {
+                        this.showEpisodeModal();
+                    });
+                }
+            }
+
+            async showEpisodeModal() {
+                const modal = document.getElementById('episode-modal');
+                const container = document.getElementById('episode-list-container');
+                
+                modal.style.display = 'block';
+                container.innerHTML = '<div class="episode-loading">Loading episodes...</div>';
+                
+                try {
+                    const episodeData = await this.episodeManager.fetchEpisodeList();
+                    this.renderEpisodeList(episodeData.episodes);
+                } catch (error) {
+                    container.innerHTML = `<div class="episode-error">Failed to load episodes: ${error.message}</div>`;
+                }
+            }
+
+            renderEpisodeList(episodes) {
+                const container = document.getElementById('episode-list-container');
+                
+                if (!episodes || episodes.length === 0) {
+                    container.innerHTML = '<div class="episode-loading">No episodes found</div>';
+                    return;
+                }
+
+                const currentEpisodeId = this.currentState?.metadata?.episode_id;
+                
+                let html = '<div class="episode-list">';
+                
+                episodes.forEach(episode => {
+                    const isCurrentEpisode = episode.episode_id === currentEpisodeId;
+                    const title = this.episodeManager.formatEpisodeTitle(episode);
+                    const duration = this.episodeManager.formatDuration(episode.duration_minutes);
+                    const statusClass = this.episodeManager.getStatusClass(episode.status);
+                    
+                    html += `
+                        <div class="episode-item ${isCurrentEpisode ? 'current-episode' : ''}" 
+                             onclick="selectEpisode('${episode.episode_id}')">
+                            <div class="episode-main-info">
+                                <div class="episode-title">${title}</div>
+                                <div class="episode-details">
+                                    Turn ${episode.final_turn}/${episode.max_turns} • ${duration} • ${episode.location}
+                                    ${episode.death_count > 0 ? ` • ${episode.death_count} deaths` : ''}
+                                </div>
+                            </div>
+                            <div class="episode-stats">
+                                <div class="episode-score">${episode.score} points</div>
+                                <div class="episode-status ${statusClass}">${episode.status}</div>
+                                ${episode.completion_percent ? `<div>${episode.completion_percent}% complete</div>` : ''}
+                            </div>
+                        </div>
+                    `;
+                });
+                
+                html += '</div>';
+                container.innerHTML = html;
+            }
+
+            async selectEpisode(episodeId) {
+                try {
+                    // Hide the modal first
+                    hideEpisodeModal();
+                    
+                    if (episodeId === this.currentState?.metadata?.episode_id) {
+                        // If selecting current episode, just return to live view
+                        this.isHistoricalView = false;
+                        this.currentEpisodeId = null;
+                        return;
+                    }
+                    
+                    // Load historical episode data
+                    const episodeData = await this.episodeManager.loadEpisodeData(episodeId);
+                    
+                    // Switch to historical view
+                    this.isHistoricalView = true;
+                    this.currentEpisodeId = episodeId;
+                    this.currentState = episodeData;
+                    
+                    // Clear historical data manager to force reload for new episode
+                    this.historicalDataManager = null;
+                    this.allLogEntries = [];
+                    this.displayedLogCount = 20;
+                    this.earliestLoadedTurn = null;
+                    
+                    // Update UI with historical data
+                    this.updateUI();
+                    
+                    // Show historical indicator
+                    this.showHistoricalIndicator(episodeId);
+                    
+                } catch (error) {
+                    console.error('Failed to load episode:', error);
+                    alert(`Failed to load episode: ${error.message}`);
+                }
+            }
+
+            showHistoricalIndicator(episodeId) {
+                const episodeElement = document.getElementById('episode-id');
+                if (episodeElement) {
+                    episodeElement.textContent = `${episodeId} (Historical)`;
+                    episodeElement.style.color = '#ffa500';
+                }
+                
+                // Add a notice to the log
+                const logContainer = document.getElementById('recent-log');
+                if (logContainer) {
+                    const notice = document.createElement('div');
+                    notice.className = 'log-entry';
+                    notice.style.backgroundColor = '#fff3cd';
+                    notice.style.border = '1px solid #ffeaa7';
+                    notice.style.borderRadius = '6px';
+                    notice.style.padding = '10px';
+                    notice.style.marginBottom = '15px';
+                    notice.innerHTML = `
+                        <div style="color: #856404; font-weight: bold;">📜 Historical Episode View</div>
+                        <div style="color: #856404; font-size: 0.9em;">
+                            You are viewing episode ${episodeId}. 
+                            <a href="#" onclick="returnToLiveView()" style="color: #007bff;">Return to live view</a>
+                        </div>
+                    `;
+                    logContainer.insertBefore(notice, logContainer.firstChild);
+                }
+            }
+
+            returnToLiveView() {
+                this.isHistoricalView = false;
+                this.currentEpisodeId = null;
+                
+                // Restart polling and fetch current state
+                this.fetchCurrentState();
+                
+                // Clear historical indicator
+                const episodeElement = document.getElementById('episode-id');
+                if (episodeElement) {
+                    episodeElement.style.color = '';
+                }
+            }
+
             updateGameInfo() {
                 const meta = this.currentState.metadata;
                 const current = this.currentState.current_state;
                 
-                document.getElementById('episode-id').textContent = meta.episode_id;
+                // Update episode ID display
+                const episodeElement = document.getElementById('episode-id');
+                if (this.isHistoricalView) {
+                    episodeElement.textContent = `${meta.episode_id} (Historical)`;
+                    episodeElement.style.color = '#ffa500';
+                } else {
+                    episodeElement.textContent = meta.episode_id;
+                    episodeElement.style.color = '';
+                }
+                
                 document.getElementById('turn-count').textContent = meta.turn_count;
                 document.getElementById('max-turns').textContent = meta.max_turns;
                 document.getElementById('score').textContent = meta.score;
@@ -1658,7 +2068,7 @@
                 try {
                     // Initialize historical data manager if needed
                     if (!this.historicalDataManager) {
-                        const episodeId = this.currentState.metadata.episode_id;
+                        const episodeId = this.currentEpisodeId || this.currentState.metadata.episode_id;
                         this.historicalDataManager = new HistoricalDataManager('./zorkgpt', episodeId);
                     }
 
@@ -1797,15 +2207,38 @@
             document.getElementById('map-modal').style.display = 'none';
         }
 
+        // Episode Modal Functions
+        function hideEpisodeModal() {
+            document.getElementById('episode-modal').style.display = 'none';
+        }
+
+        // Global function for episode selection (called from episode list)
+        function selectEpisode(episodeId) {
+            if (window.zorkViewer) {
+                window.zorkViewer.selectEpisode(episodeId);
+            }
+        }
+
+        // Global function to return to live view
+        function returnToLiveView() {
+            if (window.zorkViewer) {
+                window.zorkViewer.returnToLiveView();
+            }
+        }
+
         // Close modal when clicking outside of it
         document.addEventListener('click', function(event) {
             const faqModal = document.getElementById('faq-modal');
             const mapModal = document.getElementById('map-modal');
+            const episodeModal = document.getElementById('episode-modal');
             if (event.target === faqModal) {
                 hideFAQ();
             }
             if (event.target === mapModal) {
                 hideExpandedMap();
+            }
+            if (event.target === episodeModal) {
+                hideEpisodeModal();
             }
         });
         
@@ -1814,6 +2247,7 @@
             if (event.key === 'Escape') {
                 hideFAQ();
                 hideExpandedMap();
+                hideEpisodeModal();
             }
         });
 


### PR DESCRIPTION
Testing adding a feature with ClaudCode and a generally crappy prompt. Cost ~$3.00

```
zork_viewer.html is currently only capable of viewing the currently active episode. I would like to add a feature where the user could

  - click on the current episode id being displayed and see a list of past episodes
  - upon selecting the episode, load it into the viewer state so all the turns can be reviewed

  My initial thoughts are that this isn’t possible with the current design as there’s no index of past episodes available to the viewer, so there will need to be something that generates the index - perhaps a lambda function?
   I don’t want to add more code to the orchestrator to handle this
```

Left CORS as a wildcard.
```
There are Route53 records, and a cloud front distribution in the viewer stack, can those be set to the allowed CORS origins?
```