### PR TITLE
Testing AI code agents, Roo Code: add episode browsing

### DIFF
--- a/generate_episode_index.py
+++ b/generate_episode_index.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python3
+"""
+Episode Index Generator for ZorkGPT Viewer
+
+This script generates an index of available episodes by scanning S3 snapshots
+or local snapshot directories. It creates an episodes.json file that the viewer
+can use to list and switch between episodes.
+"""
+
+import json
+import os
+import glob
+import re
+from datetime import datetime
+from typing import List, Dict, Any, Optional
+import argparse
+
+# Optional S3 support
+try:
+    import boto3
+    S3_AVAILABLE = True
+except ImportError:
+    S3_AVAILABLE = False
+
+
+class EpisodeIndexGenerator:
+    """Generates an index of available ZorkGPT episodes."""
+    
+    def __init__(self, s3_bucket: Optional[str] = None, s3_key_prefix: str = "", local_snapshots_dir: str = "./zorkgpt/snapshots"):
+        self.s3_bucket = s3_bucket
+        self.s3_key_prefix = s3_key_prefix
+        self.local_snapshots_dir = local_snapshots_dir
+        self.s3_client = None
+        
+        if S3_AVAILABLE and s3_bucket:
+            try:
+                self.s3_client = boto3.client("s3")
+                print(f"S3 client initialized for bucket: {s3_bucket}")
+            except Exception as e:
+                print(f"Failed to initialize S3 client: {e}")
+    
+    def generate_index(self) -> Dict[str, Any]:
+        """Generate episode index from available sources."""
+        episodes = []
+        
+        # Try S3 first if available
+        if self.s3_client and self.s3_bucket:
+            print("Scanning S3 for episodes...")
+            s3_episodes = self._scan_s3_episodes()
+            episodes.extend(s3_episodes)
+            print(f"Found {len(s3_episodes)} episodes in S3")
+        
+        # Scan local snapshots
+        if os.path.exists(self.local_snapshots_dir):
+            print(f"Scanning local directory: {self.local_snapshots_dir}")
+            local_episodes = self._scan_local_episodes()
+            episodes.extend(local_episodes)
+            print(f"Found {len(local_episodes)} episodes locally")
+        else:
+            print(f"Local snapshots directory not found: {self.local_snapshots_dir}")
+        
+        # Remove duplicates and sort by timestamp
+        unique_episodes = self._deduplicate_episodes(episodes)
+        unique_episodes.sort(key=lambda x: x['start_time'], reverse=True)
+        
+        # Generate index
+        index = {
+            "generated_at": datetime.now().isoformat(),
+            "total_episodes": len(unique_episodes),
+            "episodes": unique_episodes
+        }
+        
+        print(f"Generated index with {len(unique_episodes)} unique episodes")
+        return index
+    
+    def _scan_s3_episodes(self) -> List[Dict[str, Any]]:
+        """Scan S3 for episode snapshots."""
+        episodes = []
+        
+        try:
+            # List objects in the snapshots prefix
+            snapshots_prefix = f"{self.s3_key_prefix}snapshots/"
+            
+            paginator = self.s3_client.get_paginator('list_objects_v2')
+            pages = paginator.paginate(Bucket=self.s3_bucket, Prefix=snapshots_prefix)
+            
+            episode_dirs = set()
+            
+            for page in pages:
+                if 'Contents' not in page:
+                    continue
+                    
+                for obj in page['Contents']:
+                    key = obj['Key']
+                    
+                    # Extract episode ID from path like "snapshots/2024-01-15T10:30:45/turn_1.json"
+                    match = re.match(rf"{re.escape(snapshots_prefix)}([^/]+)/turn_(\d+)\.json$", key)
+                    if match:
+                        episode_id = match.group(1)
+                        turn_num = int(match.group(2))
+                        episode_dirs.add(episode_id)
+            
+            # For each episode, get metadata from the first and last snapshots
+            for episode_id in episode_dirs:
+                episode_info = self._get_s3_episode_info(episode_id)
+                if episode_info:
+                    episodes.append(episode_info)
+                    
+        except Exception as e:
+            print(f"Error scanning S3 episodes: {e}")
+        
+        return episodes
+    
+    def _get_s3_episode_info(self, episode_id: str) -> Optional[Dict[str, Any]]:
+        """Get episode information from S3 snapshots."""
+        try:
+            episode_prefix = f"{self.s3_key_prefix}snapshots/{episode_id}/"
+            
+            # List all snapshots for this episode
+            response = self.s3_client.list_objects_v2(
+                Bucket=self.s3_bucket,
+                Prefix=episode_prefix
+            )
+            
+            if 'Contents' not in response:
+                return None
+            
+            # Find turn files and extract turn numbers
+            turn_files = []
+            for obj in response['Contents']:
+                key = obj['Key']
+                match = re.search(r'turn_(\d+)\.json$', key)
+                if match:
+                    turn_num = int(match.group(1))
+                    turn_files.append({
+                        'turn': turn_num,
+                        'key': key,
+                        'last_modified': obj['LastModified']
+                    })
+            
+            if not turn_files:
+                return None
+            
+            # Sort by turn number
+            turn_files.sort(key=lambda x: x['turn'])
+            
+            # Get first snapshot for episode metadata
+            first_snapshot_key = turn_files[0]['key']
+            first_snapshot = self._get_s3_snapshot(first_snapshot_key)
+            
+            # Get last snapshot for final stats
+            last_snapshot_key = turn_files[-1]['key']
+            last_snapshot = self._get_s3_snapshot(last_snapshot_key)
+            
+            if not first_snapshot or not last_snapshot:
+                return None
+            
+            # Extract episode information
+            episode_info = {
+                "episode_id": episode_id,
+                "source": "s3",
+                "start_time": first_snapshot.get('metadata', {}).get('timestamp', episode_id),
+                "end_time": last_snapshot.get('metadata', {}).get('timestamp', ''),
+                "total_turns": last_snapshot.get('metadata', {}).get('turn_count', len(turn_files)),
+                "final_score": last_snapshot.get('metadata', {}).get('score', 0),
+                "game_over": last_snapshot.get('metadata', {}).get('game_over', False),
+                "death_count": last_snapshot.get('current_state', {}).get('death_count', 0),
+                "models": last_snapshot.get('metadata', {}).get('models', {}),
+                "snapshot_count": len(turn_files),
+                "first_turn": turn_files[0]['turn'],
+                "last_turn": turn_files[-1]['turn']
+            }
+            
+            return episode_info
+            
+        except Exception as e:
+            print(f"Error getting S3 episode info for {episode_id}: {e}")
+            return None
+    
+    def _get_s3_snapshot(self, key: str) -> Optional[Dict[str, Any]]:
+        """Get a snapshot from S3."""
+        try:
+            response = self.s3_client.get_object(Bucket=self.s3_bucket, Key=key)
+            content = response['Body'].read().decode('utf-8')
+            return json.loads(content)
+        except Exception as e:
+            print(f"Error reading S3 snapshot {key}: {e}")
+            return None
+    
+    def _scan_local_episodes(self) -> List[Dict[str, Any]]:
+        """Scan local directory for episode snapshots."""
+        episodes = []
+        
+        try:
+            # Look for episode directories
+            episode_pattern = os.path.join(self.local_snapshots_dir, "*")
+            episode_dirs = [d for d in glob.glob(episode_pattern) if os.path.isdir(d)]
+            
+            for episode_dir in episode_dirs:
+                episode_id = os.path.basename(episode_dir)
+                episode_info = self._get_local_episode_info(episode_id, episode_dir)
+                if episode_info:
+                    episodes.append(episode_info)
+                    
+        except Exception as e:
+            print(f"Error scanning local episodes: {e}")
+        
+        return episodes
+    
+    def _get_local_episode_info(self, episode_id: str, episode_dir: str) -> Optional[Dict[str, Any]]:
+        """Get episode information from local snapshots."""
+        try:
+            # Find all turn files
+            turn_pattern = os.path.join(episode_dir, "turn_*.json")
+            turn_files = glob.glob(turn_pattern)
+            
+            if not turn_files:
+                return None
+            
+            # Extract turn numbers and sort
+            turn_info = []
+            for turn_file in turn_files:
+                match = re.search(r'turn_(\d+)\.json$', turn_file)
+                if match:
+                    turn_num = int(match.group(1))
+                    turn_info.append({
+                        'turn': turn_num,
+                        'file': turn_file,
+                        'mtime': os.path.getmtime(turn_file)
+                    })
+            
+            turn_info.sort(key=lambda x: x['turn'])
+            
+            # Read first and last snapshots
+            first_snapshot = self._read_local_snapshot(turn_info[0]['file'])
+            last_snapshot = self._read_local_snapshot(turn_info[-1]['file'])
+            
+            if not first_snapshot or not last_snapshot:
+                return None
+            
+            # Extract episode information
+            episode_info = {
+                "episode_id": episode_id,
+                "source": "local",
+                "start_time": first_snapshot.get('metadata', {}).get('timestamp', episode_id),
+                "end_time": last_snapshot.get('metadata', {}).get('timestamp', ''),
+                "total_turns": last_snapshot.get('metadata', {}).get('turn_count', len(turn_info)),
+                "final_score": last_snapshot.get('metadata', {}).get('score', 0),
+                "game_over": last_snapshot.get('metadata', {}).get('game_over', False),
+                "death_count": last_snapshot.get('current_state', {}).get('death_count', 0),
+                "models": last_snapshot.get('metadata', {}).get('models', {}),
+                "snapshot_count": len(turn_info),
+                "first_turn": turn_info[0]['turn'],
+                "last_turn": turn_info[-1]['turn']
+            }
+            
+            return episode_info
+            
+        except Exception as e:
+            print(f"Error getting local episode info for {episode_id}: {e}")
+            return None
+    
+    def _read_local_snapshot(self, file_path: str) -> Optional[Dict[str, Any]]:
+        """Read a local snapshot file."""
+        try:
+            with open(file_path, 'r') as f:
+                return json.load(f)
+        except Exception as e:
+            print(f"Error reading local snapshot {file_path}: {e}")
+            return None
+    
+    def _deduplicate_episodes(self, episodes: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Remove duplicate episodes (same episode_id from different sources)."""
+        seen = {}
+        unique_episodes = []
+        
+        for episode in episodes:
+            episode_id = episode['episode_id']
+            
+            if episode_id not in seen:
+                seen[episode_id] = episode
+                unique_episodes.append(episode)
+            else:
+                # Prefer S3 source over local if both exist
+                existing = seen[episode_id]
+                if episode['source'] == 's3' and existing['source'] == 'local':
+                    # Replace local with S3 version
+                    unique_episodes.remove(existing)
+                    unique_episodes.append(episode)
+                    seen[episode_id] = episode
+        
+        return unique_episodes
+    
+    def save_index(self, index: Dict[str, Any], output_file: str = "./zorkgpt/episodes.json") -> None:
+        """Save the episode index to a file."""
+        try:
+            # Ensure directory exists
+            os.makedirs(os.path.dirname(output_file), exist_ok=True)
+            
+            # Write index file
+            with open(output_file, 'w') as f:
+                json.dump(index, f, indent=2, default=str)
+            
+            print(f"Episode index saved to: {output_file}")
+            
+        except Exception as e:
+            print(f"Error saving episode index: {e}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate ZorkGPT episode index")
+    parser.add_argument("--s3-bucket", help="S3 bucket name")
+    parser.add_argument("--s3-prefix", default="", help="S3 key prefix")
+    parser.add_argument("--local-dir", default="./zorkgpt/snapshots", help="Local snapshots directory")
+    parser.add_argument("--output", default="./zorkgpt/episodes.json", help="Output file path")
+    
+    args = parser.parse_args()
+    
+    # Create generator
+    generator = EpisodeIndexGenerator(
+        s3_bucket=args.s3_bucket,
+        s3_key_prefix=args.s3_prefix,
+        local_snapshots_dir=args.local_dir
+    )
+    
+    # Generate index
+    print("Generating episode index...")
+    index = generator.generate_index()
+    
+    # Save index
+    generator.save_index(index, args.output)
+    
+    # Print summary
+    print(f"\nEpisode Index Summary:")
+    print(f"Total episodes: {index['total_episodes']}")
+    
+    if index['episodes']:
+        print(f"Latest episode: {index['episodes'][0]['episode_id']}")
+        print(f"Date range: {index['episodes'][-1]['start_time']} to {index['episodes'][0]['start_time']}")
+        
+        # Show some stats
+        total_turns = sum(ep['total_turns'] for ep in index['episodes'])
+        total_deaths = sum(ep['death_count'] for ep in index['episodes'])
+        max_score = max(ep['final_score'] for ep in index['episodes'])
+        
+        print(f"Total turns across all episodes: {total_turns}")
+        print(f"Total deaths: {total_deaths}")
+        print(f"Highest score achieved: {max_score}")
+
+
+if __name__ == "__main__":
+    main()

--- a/update_episode_index.py
+++ b/update_episode_index.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""
+Simple script to update the episode index for ZorkGPT viewer.
+
+This script can be run periodically (e.g., via cron) to keep the episode
+index up to date with new episodes.
+"""
+
+import sys
+import os
+from generate_episode_index import EpisodeIndexGenerator
+
+def main():
+    # Configuration - adjust these as needed
+    S3_BUCKET = None  # Set to your S3 bucket name if using S3
+    S3_PREFIX = ""    # Set to your S3 key prefix if using S3
+    LOCAL_SNAPSHOTS_DIR = "./zorkgpt/snapshots"
+    OUTPUT_FILE = "./zorkgpt/episodes.json"
+    
+    # Check if S3 bucket is provided via environment variable
+    if 'ZORKGPT_S3_BUCKET' in os.environ:
+        S3_BUCKET = os.environ['ZORKGPT_S3_BUCKET']
+        print(f"Using S3 bucket from environment: {S3_BUCKET}")
+    
+    if 'ZORKGPT_S3_PREFIX' in os.environ:
+        S3_PREFIX = os.environ['ZORKGPT_S3_PREFIX']
+        print(f"Using S3 prefix from environment: {S3_PREFIX}")
+    
+    # Create generator
+    generator = EpisodeIndexGenerator(
+        s3_bucket=S3_BUCKET,
+        s3_key_prefix=S3_PREFIX,
+        local_snapshots_dir=LOCAL_SNAPSHOTS_DIR
+    )
+    
+    try:
+        print("Generating episode index...")
+        index = generator.generate_index()
+        
+        print(f"Found {index['total_episodes']} episodes")
+        
+        # Save index
+        generator.save_index(index, OUTPUT_FILE)
+        
+        print(f"Episode index updated successfully!")
+        print(f"Index file: {OUTPUT_FILE}")
+        
+        if index['episodes']:
+            print(f"Latest episode: {index['episodes'][0]['episode_id']}")
+            print(f"Total turns across all episodes: {sum(ep['total_turns'] for ep in index['episodes'])}")
+        
+        return 0
+        
+    except Exception as e:
+        print(f"Error updating episode index: {e}", file=sys.stderr)
+        return 1
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/zork_viewer.html
+++ b/zork_viewer.html
@@ -2004,27 +2004,27 @@
                     
                     html += `
                         <div class="episode-item ${isCurrentEpisode ? 'current' : ''}"
-                             onclick="window.zorkViewer.selectEpisode('${episode.episode_id}')">
+                             onclick="window.zorkViewer.selectEpisode('${this.escapeHtml(episode.episode_id)}')">
                             <div class="episode-item-header">
-                                <div class="episode-item-id">${episode.episode_id}</div>
-                                <div class="episode-item-status ${statusClass}">${status}</div>
+                                <div class="episode-item-id">${this.escapeHtml(episode.episode_id)}</div>
+                                <div class="episode-item-status ${statusClass}">${this.escapeHtml(status)}</div>
                             </div>
                             <div class="episode-item-stats">
                                 <div class="episode-item-stat">
                                     <span>🎯</span>
-                                    <span>${episode.total_turns} turns</span>
+                                    <span>${this.escapeHtml(String(episode.total_turns))} turns</span>
                                 </div>
                                 <div class="episode-item-stat">
                                     <span>⭐</span>
-                                    <span>${episode.final_score} pts</span>
+                                    <span>${this.escapeHtml(String(episode.final_score))} pts</span>
                                 </div>
                                 <div class="episode-item-stat">
                                     <span>💀</span>
-                                    <span>${episode.death_count}</span>
+                                    <span>${this.escapeHtml(String(episode.death_count))}</span>
                                 </div>
                                 <div class="episode-item-stat">
                                     <span>📅</span>
-                                    <span>${this.formatDate(episode.start_time)}</span>
+                                    <span>${this.escapeHtml(this.formatDate(episode.start_time))}</span>
                                 </div>
                             </div>
                         </div>

--- a/zork_viewer.html
+++ b/zork_viewer.html
@@ -684,6 +684,155 @@
             text-align: center;
             margin: 5px 0;
         }
+
+        /* Episode Selector Styles */
+        .episode-selector-trigger {
+            cursor: pointer;
+            color: #007bff;
+            text-decoration: underline;
+            position: relative;
+        }
+
+        .episode-selector-trigger:hover {
+            color: #0056b3;
+        }
+
+        .episode-selector-dropdown {
+            position: absolute;
+            top: 100%;
+            left: 0;
+            right: 0;
+            background: white;
+            border: 1px solid #ddd;
+            border-radius: 8px;
+            box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+            z-index: 1000;
+            max-height: 400px;
+            overflow: hidden;
+        }
+
+        .episode-selector-header {
+            padding: 12px 16px;
+            border-bottom: 1px solid #eee;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            background: #f8f9fa;
+        }
+
+        .episode-selector-header h4 {
+            margin: 0;
+            color: #333;
+            font-size: 16px;
+        }
+
+        .close-btn {
+            background: none;
+            border: none;
+            font-size: 20px;
+            cursor: pointer;
+            color: #666;
+            padding: 0;
+            width: 24px;
+            height: 24px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .close-btn:hover {
+            color: #333;
+        }
+
+        .episode-selector-content {
+            max-height: 320px;
+            overflow-y: auto;
+        }
+
+        .episode-list {
+            padding: 8px;
+        }
+
+        .episode-item {
+            padding: 12px;
+            border: 1px solid #eee;
+            border-radius: 6px;
+            margin-bottom: 8px;
+            cursor: pointer;
+            transition: background-color 0.2s;
+        }
+
+        .episode-item:hover {
+            background-color: #f8f9fa;
+        }
+
+        .episode-item.current {
+            background-color: #e3f2fd;
+            border-color: #2196f3;
+        }
+
+        .episode-item-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 4px;
+        }
+
+        .episode-item-id {
+            font-weight: bold;
+            color: #333;
+            font-size: 14px;
+        }
+
+        .episode-item-status {
+            font-size: 12px;
+            padding: 2px 6px;
+            border-radius: 3px;
+            color: white;
+        }
+
+        .episode-status-completed {
+            background-color: #4caf50;
+        }
+
+        .episode-status-died {
+            background-color: #f44336;
+        }
+
+        .episode-status-ongoing {
+            background-color: #ff9800;
+        }
+
+        .episode-item-stats {
+            font-size: 12px;
+            color: #666;
+            display: flex;
+            gap: 12px;
+        }
+
+        .episode-item-stat {
+            display: flex;
+            align-items: center;
+            gap: 4px;
+        }
+
+        /* Mobile responsive episode selector */
+        @media (max-width: 768px) {
+            .episode-selector-dropdown {
+                position: fixed;
+                top: 0;
+                left: 0;
+                right: 0;
+                bottom: 0;
+                max-height: none;
+                border-radius: 0;
+                border: none;
+            }
+
+            .episode-selector-content {
+                max-height: calc(100vh - 60px);
+            }
+        }
     </style>
 </head>
 <body>
@@ -704,8 +853,20 @@
                 </div>
             </div>
             <div class="info-grid">
-                <div class="info-item">
-                    <strong>Episode:</strong> <span id="episode-id">Loading...</span>
+                <div class="info-item" style="position: relative;">
+                    <strong>Episode:</strong>
+                    <span id="episode-id" class="episode-selector-trigger" title="Click to select episode">Loading...</span>
+                    <div id="episode-selector" class="episode-selector-dropdown" style="display: none;">
+                        <div class="episode-selector-header">
+                            <h4>Select Episode</h4>
+                            <button onclick="hideEpisodeSelector()" class="close-btn">&times;</button>
+                        </div>
+                        <div class="episode-selector-content">
+                            <div id="episode-list" class="episode-list">
+                                <div class="loading">Loading episodes...</div>
+                            </div>
+                        </div>
+                    </div>
                 </div>
                 <div class="info-item">
                     <strong>Turn:</strong> <span id="turn-count">-</span> / <span id="max-turns">-</span>
@@ -1103,10 +1264,22 @@
                 this.isLoadingHistorical = false;
                 this.earliestLoadedTurn = null;
                 
+                // Episode management
+                this.availableEpisodes = [];
+                this.currentEpisodeId = null;
+                this.isViewingHistoricalEpisode = false;
+                
                 this.startPolling();
+                this.loadEpisodeIndex();
+                this.setupEpisodeSelector();
             }
             
             async fetchCurrentState() {
+                // Skip polling if viewing historical episode
+                if (this.isViewingHistoricalEpisode) {
+                    return;
+                }
+
                 try {
                     const response = await fetch(this.stateUrl);
                     if (response.ok) {
@@ -1116,7 +1289,7 @@
                         const isFresh = this.isTimestampFresh(newState.metadata.timestamp);
                         
                         // Only update if state actually changed
-                        if (!this.currentState || 
+                        if (!this.currentState ||
                             this.currentState.metadata.turn_count !== newState.metadata.turn_count ||
                             this.currentState.metadata.timestamp !== newState.metadata.timestamp) {
                             this.currentState = newState;
@@ -1772,6 +1945,229 @@
                 
                 html += '</div>';
                 return html;
+            }
+
+            // Episode management methods
+            async loadEpisodeIndex() {
+                try {
+                    const response = await fetch('./zorkgpt/episodes.json');
+                    if (response.ok) {
+                        const episodeIndex = await response.json();
+                        this.availableEpisodes = episodeIndex.episodes || [];
+                        console.log(`Loaded ${this.availableEpisodes.length} episodes from index`);
+                        this.updateEpisodeSelector();
+                    } else {
+                        console.warn('Episode index not found, episode selection disabled');
+                    }
+                } catch (error) {
+                    console.warn('Failed to load episode index:', error);
+                }
+            }
+
+            setupEpisodeSelector() {
+                const episodeIdElement = document.getElementById('episode-id');
+                if (episodeIdElement) {
+                    episodeIdElement.addEventListener('click', () => {
+                        if (this.availableEpisodes.length > 0) {
+                            this.showEpisodeSelector();
+                        }
+                    });
+                }
+
+                // Close episode selector when clicking outside
+                document.addEventListener('click', (event) => {
+                    const episodeSelector = document.getElementById('episode-selector');
+                    const episodeIdElement = document.getElementById('episode-id');
+                    
+                    if (episodeSelector &&
+                        !episodeSelector.contains(event.target) &&
+                        !episodeIdElement.contains(event.target)) {
+                        this.hideEpisodeSelector();
+                    }
+                });
+            }
+
+            updateEpisodeSelector() {
+                const episodeList = document.getElementById('episode-list');
+                if (!episodeList || this.availableEpisodes.length === 0) {
+                    return;
+                }
+
+                let html = '';
+                
+                for (const episode of this.availableEpisodes) {
+                    const isCurrentEpisode = this.currentState &&
+                        this.currentState.metadata.episode_id === episode.episode_id;
+                    
+                    const status = this.getEpisodeStatus(episode);
+                    const statusClass = `episode-status-${status.toLowerCase()}`;
+                    
+                    html += `
+                        <div class="episode-item ${isCurrentEpisode ? 'current' : ''}"
+                             onclick="window.zorkViewer.selectEpisode('${episode.episode_id}')">
+                            <div class="episode-item-header">
+                                <div class="episode-item-id">${episode.episode_id}</div>
+                                <div class="episode-item-status ${statusClass}">${status}</div>
+                            </div>
+                            <div class="episode-item-stats">
+                                <div class="episode-item-stat">
+                                    <span>🎯</span>
+                                    <span>${episode.total_turns} turns</span>
+                                </div>
+                                <div class="episode-item-stat">
+                                    <span>⭐</span>
+                                    <span>${episode.final_score} pts</span>
+                                </div>
+                                <div class="episode-item-stat">
+                                    <span>💀</span>
+                                    <span>${episode.death_count}</span>
+                                </div>
+                                <div class="episode-item-stat">
+                                    <span>📅</span>
+                                    <span>${this.formatDate(episode.start_time)}</span>
+                                </div>
+                            </div>
+                        </div>
+                    `;
+                }
+
+                episodeList.innerHTML = html;
+            }
+
+            getEpisodeStatus(episode) {
+                if (episode.game_over) {
+                    return episode.death_count > 0 ? 'Died' : 'Completed';
+                }
+                return 'Ongoing';
+            }
+
+            formatDate(dateString) {
+                try {
+                    const date = new Date(dateString);
+                    return date.toLocaleDateString();
+                } catch (error) {
+                    return dateString.split('T')[0]; // Fallback to date part
+                }
+            }
+
+            showEpisodeSelector() {
+                const episodeSelector = document.getElementById('episode-selector');
+                if (episodeSelector) {
+                    episodeSelector.style.display = 'block';
+                    this.updateEpisodeSelector(); // Refresh the list
+                }
+            }
+
+            hideEpisodeSelector() {
+                const episodeSelector = document.getElementById('episode-selector');
+                if (episodeSelector) {
+                    episodeSelector.style.display = 'none';
+                }
+            }
+
+            async selectEpisode(episodeId) {
+                console.log(`Selecting episode: ${episodeId}`);
+                this.hideEpisodeSelector();
+
+                // Check if this is the current live episode
+                const isCurrentLiveEpisode = this.currentState &&
+                    this.currentState.metadata.episode_id === episodeId;
+
+                if (isCurrentLiveEpisode && !this.isViewingHistoricalEpisode) {
+                    console.log('Already viewing current live episode');
+                    return;
+                }
+
+                // Find episode info
+                const episodeInfo = this.availableEpisodes.find(ep => ep.episode_id === episodeId);
+                if (!episodeInfo) {
+                    console.error('Episode not found:', episodeId);
+                    return;
+                }
+
+                try {
+                    // Switch to historical episode mode
+                    this.isViewingHistoricalEpisode = !isCurrentLiveEpisode;
+                    this.currentEpisodeId = episodeId;
+
+                    if (this.isViewingHistoricalEpisode) {
+                        // Load the latest snapshot for this episode
+                        await this.loadHistoricalEpisode(episodeInfo);
+                    } else {
+                        // Switch back to live mode
+                        this.resumeLiveMode();
+                    }
+
+                } catch (error) {
+                    console.error('Failed to switch episode:', error);
+                    // Reset to live mode on error
+                    this.isViewingHistoricalEpisode = false;
+                    this.currentEpisodeId = null;
+                }
+            }
+
+            async loadHistoricalEpisode(episodeInfo) {
+                console.log('Loading historical episode:', episodeInfo.episode_id);
+
+                try {
+                    // Load the final snapshot for this episode
+                    const snapshotUrl = `./zorkgpt/snapshots/${episodeInfo.episode_id}/turn_${episodeInfo.last_turn}.json`;
+                    const response = await fetch(snapshotUrl);
+
+                    if (!response.ok) {
+                        throw new Error(`Failed to load episode snapshot: ${response.status}`);
+                    }
+
+                    const historicalState = await response.json();
+                    
+                    // Update current state with historical data
+                    this.currentState = historicalState;
+                    
+                    // Reset historical data manager for this episode
+                    this.historicalDataManager = new HistoricalDataManager('./zorkgpt', episodeInfo.episode_id);
+                    this.allLogEntries = [];
+                    this.displayedLogCount = 20;
+                    this.earliestLoadedTurn = null;
+                    
+                    // Update UI
+                    this.updateUI();
+                    
+                    // Update episode ID display to show it's historical
+                    const episodeIdElement = document.getElementById('episode-id');
+                    if (episodeIdElement) {
+                        episodeIdElement.textContent = `${episodeInfo.episode_id} (Historical)`;
+                        episodeIdElement.style.color = '#ff9800'; // Orange to indicate historical
+                    }
+
+                    console.log('Historical episode loaded successfully');
+
+                } catch (error) {
+                    console.error('Failed to load historical episode:', error);
+                    throw error;
+                }
+            }
+
+            resumeLiveMode() {
+                console.log('Resuming live mode');
+                
+                this.isViewingHistoricalEpisode = false;
+                this.currentEpisodeId = null;
+                
+                // Reset episode ID display style
+                const episodeIdElement = document.getElementById('episode-id');
+                if (episodeIdElement) {
+                    episodeIdElement.style.color = '#007bff'; // Back to blue
+                }
+                
+                // Force refresh of current state
+                this.fetchCurrentState();
+            }
+        }
+
+        // Episode Selector Functions
+        function hideEpisodeSelector() {
+            if (window.zorkViewer) {
+                window.zorkViewer.hideEpisodeSelector();
             }
         }
 


### PR DESCRIPTION
Testing adding a feature with RooCode and a generally crappy prompt. Cost ~$1.09

```
zork_viewer.html is currently only capable of viewing the currently active episode. I would like to add a feature where the user could

  - click on the current episode id being displayed and see a list of past episodes
  - upon selecting the episode, load it into the viewer state so all the turns can be reviewed

  My initial thoughts are that this isn’t possible with the current design as there’s no index of past episodes available to the viewer, so there will need to be something that generates the index - perhaps a lambda function?
   I don’t want to add more code to the orchestrator to handle this
```